### PR TITLE
feat(rateLimit) Skip rate limiter for relay

### DIFF
--- a/facesign-service/server.ts
+++ b/facesign-service/server.ts
@@ -46,6 +46,7 @@ const limiter = rateLimit({
   legacyHeaders: false,
   standardHeaders: false,
   ipv6Subnet: 56,
+  skip: (req) => req.url.startsWith("/relay/"), // This is called from internal network, so we don't need to rate limit it
 });
 
 app.set("trust proxy", "loopback");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Relay endpoints are now properly excluded from rate limiting, allowing them to operate without throttling restrictions while other routes maintain existing rate-limit protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->