### PR TITLE
feat(match) During match we should be able to resolve uniqueness too

### DIFF
--- a/facesign-service/openapi.yaml
+++ b/facesign-service/openapi.yaml
@@ -77,7 +77,7 @@ paths:
   /relay/liveness:
     post:
       tags: [Relay]
-      summary: 3D liveness / enrollment (no group deduplication)
+      summary: 3D liveness check
       operationId: postRelayLiveness
       security:
         - RelayJwt: []
@@ -118,7 +118,7 @@ paths:
   /relay/uniqueness:
     post:
       tags: [Relay]
-      summary: Uniqueness / group enrollment with deduplication
+      summary: Liveness 3D check + 3D-DB group de-duplication
       operationId: postRelayUniqueness
       security:
         - RelayJwt: []
@@ -165,7 +165,7 @@ paths:
   /relay/match:
     post:
       tags: [Relay]
-      summary: 3D–3D match against an enrolled user
+      summary: 3D–3D match against an enrolled user and optional group de-duplication
       operationId: postRelayMatch
       security:
         - RelayJwt: []
@@ -185,7 +185,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/SessionStartResponse"
         "201":
-          description: Match completed successfully.
+          description: Match (and uniqueness if required) completed successfully.
           content:
             application/json:
               schema:
@@ -196,6 +196,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/MatchFailureBody"
+        "409":
+          description: Non-recoverable duplicate face-vector (FFR) during uniqueness.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConflictErrorBody"
         "401":
           $ref: "#/components/responses/UnauthorizedRelay"
         "503":
@@ -568,6 +574,9 @@ components:
           format: uuid
         requestBlob:
           type: string
+        groupName:
+          type: string
+          description: "This is uniqueness + match when liveness was done first"
         storeSelfie:
           type: boolean
           default: false
@@ -581,6 +590,19 @@ components:
               type: string
               nullable: true
               description: Same as `userId` when `storeSelfie` was true; otherwise null.
+            groupResolution:
+              type: object
+              nullable: true
+              description: "When group is provided (uniqueness process is used), we need to know the userId"
+              properties:
+                userId:
+                  type: string
+                  format: uuid
+                newUser:
+                  type: boolean
+              required:
+                - userId
+                - newUser
 
     MatchFailureBody:
       allOf:

--- a/facesign-service/openapi.yaml
+++ b/facesign-service/openapi.yaml
@@ -592,7 +592,6 @@ components:
               description: Same as `userId` when `storeSelfie` was true; otherwise null.
             groupResolution:
               type: object
-              nullable: true
               description: "When group is provided (uniqueness process is used), we need to know the userId"
               properties:
                 userId:

--- a/facesign-service/providers/api.ts
+++ b/facesign-service/providers/api.ts
@@ -22,6 +22,7 @@ export interface Enrollment3DResponseData {
   result: {
     livenessProven: boolean;
   };
+  launchId?: string;
 }
 
 function checkSessionStartResponse(response: ProcessRequestResponse) {

--- a/facesign-service/routes/facesign.ts
+++ b/facesign-service/routes/facesign.ts
@@ -81,6 +81,10 @@ export const confirmation = async (req: Request, res: Response) => {
   // Check duplications (race-condition)
   const searchResult = await searchForDuplicates({ userId, groupName: FACE_SIGN_GROUP_NAME });
   if (!searchResult.success || searchResult.results.length > 0) {
+    agent.writeLog("facesign-user-already-exists", {
+      userId,
+      searchResult,
+    });
     return res.status(409).json({ errorMessage: "User already exists" });
   }
 

--- a/facesign-service/routes/liveness.ts
+++ b/facesign-service/routes/liveness.ts
@@ -17,8 +17,8 @@ export interface LivenessRequestData {
 }
 
 export interface LivenessResponseData extends Enrollment3DResponseData {
-  userId?: string;
   faceSign?: FaceSignLoginNew | FaceSignLoginExisting | FaceSignLoginCreated;
+  userId?: string;
   selfieImageId?: string;
 }
 
@@ -47,9 +47,10 @@ export default async function handler(req: Request, res: Response) {
     success,
     responseBlob,
     didError,
-    additionalSessionData, // This can be used for POU credentials
+    additionalSessionData,
     result,
-    userId,
+    launchId,
+    userId, // This is used to tied externalUserId with a face-map
   };
 
   // If the user is already enrolled, we will return a different

--- a/facesign-service/routes/match.ts
+++ b/facesign-service/routes/match.ts
@@ -1,17 +1,19 @@
 import type { Request, Response } from "express";
 import agent from "../providers/agent.ts";
 import { match3d3d } from "../providers/api.ts";
+import { findOrEnrollInGroup } from "../providers/groups.ts";
 
 export default async function handler(req: Request, res: Response) {
-  const { requestBlob, userId, storeSelfie = false } = req.body;
+  const { requestBlob, userId, groupName, storeSelfie = false } = req.body;
 
-  agent.writeLog("match-request", { userId, storeSelfie });
+  agent.writeLog("match-request", { userId, groupName, storeSelfie });
 
-  const { success, result, responseBlob, didError, additionalSessionData } = await match3d3d({
-    userId,
-    requestBlob,
-    storeSelfie,
-  });
+  const { success, result, responseBlob, didError, additionalSessionData, launchId } =
+    await match3d3d({
+      userId,
+      requestBlob,
+      storeSelfie,
+    });
 
   // Always return required fields for SDK
   const alwaysToReturn = {
@@ -20,6 +22,7 @@ export default async function handler(req: Request, res: Response) {
     didError,
     result,
     additionalSessionData,
+    launchId,
   };
 
   if (!success || didError) {
@@ -37,11 +40,36 @@ export default async function handler(req: Request, res: Response) {
     identifier: userId,
     matchLevel: result.matchLevel,
     selfieImageId: storeSelfie ? userId : null,
+    launchId,
+  });
+
+  if (!groupName) {
+    return res.status(201).json({
+      ...alwaysToReturn,
+      // During matching, there is no enrollment record, only Reverification3D3D record
+      selfieImageId: storeSelfie ? userId : null,
+    });
+  }
+
+  // TODO: What we are gonna do with faceMap vs faceVector?
+
+  // Group name means matching + uniqueness, so we need to check the user for the group
+  const { groupUserId, newUser } = await findOrEnrollInGroup({
+    userId,
+    groupName,
+    launchId,
+    process: "uniqueness",
+    enrollIfNew: true,
   });
 
   return res.status(201).json({
     ...alwaysToReturn,
     // During matching, there is no enrollment record, only Reverification3D3D record
     selfieImageId: storeSelfie ? userId : null,
+    // When we are doing uniqueness, we need to return the group resolution result
+    groupResolution: {
+      userId: groupUserId,
+      newUser,
+    },
   });
 }

--- a/facesign-service/tests/facesign/confirmation.test.ts
+++ b/facesign-service/tests/facesign/confirmation.test.ts
@@ -2,6 +2,7 @@
 import { generateKeyPairSync } from "node:crypto";
 import { ObjectId } from "mongodb";
 import request from "supertest";
+import agent from "../../providers/agent.ts";
 import { describe, expect, it, vi } from "vitest";
 import * as db from "../../providers/db.ts";
 import app from "../../server.ts";
@@ -63,12 +64,19 @@ describe("FaceSign/Confirmation API", () => {
       action: "confirmation",
     });
 
+    const agentSpy = vi.spyOn(agent, "writeLog").mockImplementation(() => {});
+
     const response = await request(app).post("/facesign/confirmation").send({
       newUserConfirmationToken: token,
     });
 
     expect(response.status).toBe(409);
     expect(response.body.errorMessage).toBe("User already exists");
+
+    expect(agentSpy).toHaveBeenCalledWith("facesign-user-already-exists", {
+      userId,
+      searchResult: { success: true, results: [{ identifier: "different-user-id", matchLevel: 15 }] },
+    });
   });
 
   it("everything ok", async () => {

--- a/facesign-service/tests/liveness/facesign-onboarding.test.ts
+++ b/facesign-service/tests/liveness/facesign-onboarding.test.ts
@@ -53,6 +53,7 @@ describe("Liveness + Facesign Onboarding API", () => {
         userId: expect.any(String),
         userAttestmentToken: expect.any(String),
       },
+      launchId: expect.any(String),
       success: true,
     });
 
@@ -123,6 +124,7 @@ describe("Liveness + Facesign Onboarding API", () => {
         userId: "existing-user-id",
         userAttestmentToken: expect.any(String),
       },
+      launchId: expect.any(String),
       success: true,
     });
 

--- a/facesign-service/tests/liveness/normal.test.ts
+++ b/facesign-service/tests/liveness/normal.test.ts
@@ -85,6 +85,7 @@ describe("Liveness API", () => {
       success: true,
       userId: expect.any(String),
       selfieImageId: expect.any(String),
+      launchId: expect.any(String),
     });
 
     // New user audit trail image ID should be the same as userId

--- a/facesign-service/tests/match/match-with-uniqueness.test.ts
+++ b/facesign-service/tests/match/match-with-uniqueness.test.ts
@@ -1,0 +1,228 @@
+// biome-ignore-all lint/suspicious/noExplicitAny: Test files often need any
+
+import { ObjectId } from "mongodb";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+import agent from "../../providers/agent.ts";
+import * as db from "../../providers/db.ts";
+import app from "../../server.ts";
+import { relayAuthorizationHeader } from "../utils/helper.ts";
+import { processRequestHandler, requestCapture, searchHandler } from "../utils/msw-handlers.ts";
+import { server } from "../utils/msw-server.ts";
+
+describe("Match API (+ uniqueness)", () => {
+  it("user match (level 15) + uniqueness (new user)", async () => {
+    server.use(
+      processRequestHandler({
+        success: true,
+        result: { livenessProven: true, matchLevel: 15 },
+        didError: false,
+        responseBlob: "mock-scan-result-blob",
+      }),
+      searchHandler([]),
+    );
+
+    const agentSpy = vi.spyOn(agent, "writeLog").mockImplementation(() => {});
+
+    const insertMemberSpy = vi.spyOn(db, "insertMember").mockResolvedValue({
+      acknowledged: true,
+      insertedId: new ObjectId(),
+    });
+
+    const response = await request(app).post("/relay/match").set(relayAuthorizationHeader()).send({
+      requestBlob: "test-face-scan",
+      userId: "test-user-id",
+      storeSelfie: true,
+      groupName: "test-users",
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toEqual({
+      didError: false,
+      responseBlob: "mock-scan-result-blob",
+      result: { livenessProven: true, matchLevel: 15 },
+      success: true,
+      launchId: expect.any(String),
+      selfieImageId: expect.any(String),
+      groupResolution: {
+        userId: "test-user-id",
+        newUser: true,
+      },
+    });
+
+    expect(agentSpy).toHaveBeenCalledWith("match-request", {
+      userId: "test-user-id",
+      storeSelfie: true,
+      groupName: "test-users",
+    });
+
+    expect(agentSpy).toHaveBeenCalledWith("match-3d-3d-done", {
+      identifier: "test-user-id",
+      matchLevel: 15,
+      launchId: expect.any(String),
+      selfieImageId: expect.any(String),
+    });
+
+    expect(agentSpy).toHaveBeenCalledWith("group-resolution-new-user-enrolled", {
+      userId: "test-user-id",
+      groupName: "test-users",
+      launchId: expect.any(String),
+      process: "uniqueness",
+    });
+
+    // Verify FaceTec API calls
+    const processRequest = requestCapture.getLastByEndpoint("/process-request");
+    expect(processRequest?.body).toMatchObject({
+      externalDatabaseRefID: "test-user-id",
+      requestBlob: "test-face-scan",
+    });
+
+    const searchRequest = requestCapture.getLastByEndpoint("/3d-db/search");
+    expect(searchRequest?.body).toMatchObject({
+      externalDatabaseRefID: "test-user-id",
+      groupName: "test-users",
+    });
+
+    expect(insertMemberSpy).toHaveBeenCalledWith({
+      groupName: "test-users",
+      userId: "test-user-id",
+    });
+  });
+
+  it("user match (level 15) + uniqueness (existing user)", async () => {
+    server.use(
+      processRequestHandler({
+        success: true,
+        result: { livenessProven: true, matchLevel: 15 },
+        didError: false,
+        responseBlob: "mock-scan-result-blob",
+      }),
+      searchHandler([{ identifier: "test-user-id2", matchLevel: 15 }]),
+    );
+
+    const agentSpy = vi.spyOn(agent, "writeLog").mockImplementation(() => {});
+
+    const insertMemberSpy = vi.spyOn(db, "insertMember").mockResolvedValue({
+      acknowledged: true,
+      insertedId: new ObjectId(),
+    });
+
+    const response = await request(app).post("/relay/match").set(relayAuthorizationHeader()).send({
+      requestBlob: "test-face-scan",
+      userId: "test-user-id",
+      storeSelfie: true,
+      groupName: "test-users",
+    });
+
+    expect(response.status).toBe(201);
+    expect(response.body).toEqual({
+      didError: false,
+      responseBlob: "mock-scan-result-blob",
+      result: { livenessProven: true, matchLevel: 15 },
+      success: true,
+      launchId: expect.any(String),
+      selfieImageId: expect.any(String),
+      groupResolution: {
+        userId: "test-user-id2",
+        newUser: false,
+      },
+    });
+
+    expect(agentSpy).toHaveBeenCalledWith("match-request", {
+      userId: "test-user-id",
+      storeSelfie: true,
+      groupName: "test-users",
+    });
+
+    expect(agentSpy).toHaveBeenCalledWith("match-3d-3d-done", {
+      identifier: "test-user-id",
+      matchLevel: 15,
+      launchId: expect.any(String),
+      selfieImageId: expect.any(String),
+    });
+
+    expect(agentSpy).toHaveBeenCalledWith("group-resolution-existing-user", {
+      userId: "test-user-id",
+      count: 1,
+      groupName: "test-users",
+      launchId: expect.any(String),
+      matchedUserIds: ["test-user-id2"],
+      resolvedUserId: "test-user-id2",
+      process: "uniqueness",
+    });
+
+    // Verify FaceTec API calls
+    const processRequest = requestCapture.getLastByEndpoint("/process-request");
+    expect(processRequest?.body).toMatchObject({
+      externalDatabaseRefID: "test-user-id",
+      requestBlob: "test-face-scan",
+    });
+
+    const searchRequest = requestCapture.getLastByEndpoint("/3d-db/search");
+    expect(searchRequest?.body).toMatchObject({
+      externalDatabaseRefID: "test-user-id",
+      groupName: "test-users",
+    });
+
+    expect(insertMemberSpy).not.toHaveBeenCalled();
+  });
+
+  it("user match (level 15) + uniqueness (FFR)", async () => {
+    server.use(
+      processRequestHandler({
+        success: true,
+        result: { livenessProven: true, matchLevel: 15 },
+        didError: false,
+        responseBlob: "mock-scan-result-blob",
+      }),
+      searchHandler([
+        { identifier: "test-user-id2", matchLevel: 15 },
+        { identifier: "test-user-id3", matchLevel: 15 },
+        { identifier: "test-user-id4", matchLevel: 15 },
+      ]),
+    );
+
+    const agentSpy = vi.spyOn(agent, "writeLog").mockImplementation(() => {});
+
+    const insertMemberSpy = vi.spyOn(db, "insertMember").mockResolvedValue({
+      acknowledged: true,
+      insertedId: new ObjectId(),
+    });
+
+    const response = await request(app).post("/relay/match").set(relayAuthorizationHeader()).send({
+      requestBlob: "test-face-scan",
+      userId: "test-user-id",
+      storeSelfie: true,
+      groupName: "test-users",
+    });
+
+    expect(response.status).toBe(409);
+    expect(response.body).toEqual({
+      errorMessage: "Enrollment process failed, multiple users found with the same face-vector.",
+    });
+
+    expect(agentSpy).toHaveBeenCalledWith("match-request", {
+      userId: "test-user-id",
+      storeSelfie: true,
+      groupName: "test-users",
+    });
+
+    expect(agentSpy).toHaveBeenCalledWith("match-3d-3d-done", {
+      identifier: "test-user-id",
+      matchLevel: 15,
+      launchId: expect.any(String),
+      selfieImageId: expect.any(String),
+    });
+
+    expect(agentSpy).toHaveBeenCalledWith("group-resolution-ffr-rejected", {
+      userId: "test-user-id",
+      count: 3,
+      groupName: "test-users",
+      launchId: expect.any(String),
+      matchedUserIds: ["test-user-id2", "test-user-id3", "test-user-id4"],
+      process: "uniqueness",
+    });
+
+    expect(insertMemberSpy).not.toHaveBeenCalled();
+  });
+});

--- a/facesign-service/tests/match/match.test.ts
+++ b/facesign-service/tests/match/match.test.ts
@@ -49,17 +49,20 @@ describe("Match API", () => {
       responseBlob: "mock-scan-result-blob",
       result: { livenessProven: true, matchLevel: 15 },
       success: true,
+      launchId: expect.any(String),
       selfieImageId: expect.any(String),
     });
 
     expect(agentSpy).toHaveBeenCalledWith("match-request", {
       userId: "test-user-id",
       storeSelfie: true,
+      groupName: undefined,
     });
 
     expect(agentSpy).toHaveBeenCalledWith("match-3d-3d-done", {
       identifier: "test-user-id",
       matchLevel: 15,
+      launchId: expect.any(String),
       selfieImageId: expect.any(String),
     });
 
@@ -92,6 +95,7 @@ describe("Match API", () => {
     expect(response.body).toEqual({
       errorMessage: "Liveness check or enrollment 3D failed and was not processed.",
       success: false,
+      launchId: expect.any(String),
       didError: false,
       responseBlob: "invalid-result-blob",
       result: { livenessProven: false },
@@ -126,6 +130,7 @@ describe("Match API", () => {
       errorMessage: "Liveness check or enrollment 3D failed and was not processed.",
       success: false,
       didError: false,
+      launchId: expect.any(String),
       responseBlob: "invalid-result-blob",
       result: { livenessProven: true },
     });


### PR DESCRIPTION
This is related to our talk @pkoch 

If user do first +liveness and than +uniqueness is requested, we are doing matching. So during the match process, we have to be able to also resolve uniqueness membership.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional group-aware matching: requests can include a group and responses may return resolved group identity (userId + newUser)
  * Added launchId to relevant API responses for session tracking

* **Documentation**
  * Endpoint descriptions clarified to reflect 3D liveness checks and optional group de-duplication in the liveness→uniqueness→match flow

* **Bug Fixes**
  * New 409 conflict response for non-recoverable duplicate face-vector conflicts

* **Tests**
  * Added integration tests covering match + uniqueness scenarios

* **Chores**
  * Additional log emission when duplicate user detected
<!-- end of auto-generated comment: release notes by coderabbit.ai -->